### PR TITLE
pkg_logger.go:  - introduce logf internal methods which is adding

### DIFF
--- a/example/hello_dolly.go
+++ b/example/hello_dolly.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	oldlog "log"
+	"os"
 
 	"github.com/coreos/pkg/capnslog"
 )
@@ -53,5 +54,17 @@ func main() {
 	// We also have control over the built-in "log" package.
 	capnslog.SetGlobalLogLevel(logLevel)
 	oldlog.Println("You're still glowin', you're still crowin', you're still lookin' strong")
+	// "log" can be also fully integrated as Formatter, while sill using it's format flags
+	capnslog.SetFormatter(capnslog.NewLogFormatter(os.Stderr, "", oldlog.LstdFlags | oldlog.Lshortfile))
+	log.Error("I feel the room swayin'...")
+	log.Errorf("...for the band's playin'")
+
+	// We can mimic glog's output
+	// (Caller via direct vs wrapped call to internalLog)
+	capnslog.SetFormatter(capnslog.NewGlogFormatter(os.Stderr))
+	log.Error("I hear the ice tinkle")
+	log.Errorf("See the lights twinkle")
+
+	capnslog.SetFormatter(capnslog.NewDefaultFormatter(os.Stderr))
 	log.Fatalf("Dolly'll never go away again")
 }

--- a/formatters.go
+++ b/formatters.go
@@ -39,11 +39,11 @@ type StringFormatter struct {
 	w *bufio.Writer
 }
 
-func (s *StringFormatter) Format(pkg string, l LogLevel, i int, entries ...interface{}) {
+func (s *StringFormatter) Format(pkg string, l LogLevel, depth int, entries ...interface{}) {
 	now := time.Now().UTC()
 	s.w.WriteString(now.Format(time.RFC3339))
 	s.w.WriteByte(' ')
-	writeEntries(s.w, pkg, l, i, entries...)
+	writeEntries(s.w, pkg, l, depth+1, entries...)
 	s.Flush()
 }
 
@@ -98,7 +98,7 @@ func (c *PrettyFormatter) Format(pkg string, l LogLevel, depth int, entries ...i
 		c.w.WriteString(fmt.Sprintf(" [%s:%d]", file, line))
 	}
 	c.w.WriteString(fmt.Sprint(" ", l.Char(), " | "))
-	writeEntries(c.w, pkg, l, depth, entries...)
+	writeEntries(c.w, pkg, l, depth+1, entries...)
 	c.Flush()
 }
 
@@ -122,13 +122,13 @@ func NewLogFormatter(w io.Writer, prefix string, flag int) Formatter {
 }
 
 // Format builds a log message for the LogFormatter. The LogLevel is ignored.
-func (lf *LogFormatter) Format(pkg string, _ LogLevel, _ int, entries ...interface{}) {
+func (lf *LogFormatter) Format(pkg string, _ LogLevel, depth int, entries ...interface{}) {
 	str := fmt.Sprint(entries...)
 	prefix := lf.prefix
 	if pkg != "" {
 		prefix = fmt.Sprintf("%s%s: ", prefix, pkg)
 	}
-	lf.logger.Output(5, fmt.Sprintf("%s%v", prefix, str)) // call depth is 5
+	lf.logger.Output(depth+1, fmt.Sprintf("%s%v", prefix, str)) // call depth should be calculated
 }
 
 // Flush is included so that the interface is complete, but is a no-op.

--- a/pkg_logger.go
+++ b/pkg_logger.go
@@ -45,12 +45,16 @@ func (p *PackageLogger) LevelAt(l LogLevel) bool {
 
 // Log a formatted string at any level between ERROR and TRACE
 func (p *PackageLogger) Logf(l LogLevel, format string, args ...interface{}) {
-	p.internalLog(calldepth, l, fmt.Sprintf(format, args...))
+	p.logf(calldepth, l, format, args...)
 }
 
 // Log a message at any level between ERROR and TRACE
 func (p *PackageLogger) Log(l LogLevel, args ...interface{}) {
 	p.internalLog(calldepth, l, fmt.Sprint(args...))
+}
+
+func (p *PackageLogger) logf(depth int, l LogLevel, format string, args ...interface{}) {
+	p.internalLog(depth + 1, l, fmt.Sprintf(format, args...))
 }
 
 // log stdlib compatibility
@@ -60,7 +64,7 @@ func (p *PackageLogger) Println(args ...interface{}) {
 }
 
 func (p *PackageLogger) Printf(format string, args ...interface{}) {
-	p.Logf(INFO, format, args...)
+	p.logf(calldepth, INFO, format, args...)
 }
 
 func (p *PackageLogger) Print(args ...interface{}) {
@@ -82,7 +86,7 @@ func (p *PackageLogger) Panic(args ...interface{}) {
 }
 
 func (p *PackageLogger) Fatalf(format string, args ...interface{}) {
-	p.Logf(CRITICAL, format, args...)
+	p.logf(calldepth, CRITICAL, format, args...)
 	os.Exit(1)
 }
 
@@ -101,7 +105,7 @@ func (p *PackageLogger) Fatalln(args ...interface{}) {
 // Error Functions
 
 func (p *PackageLogger) Errorf(format string, args ...interface{}) {
-	p.Logf(ERROR, format, args...)
+	p.logf(calldepth, ERROR, format, args...)
 }
 
 func (p *PackageLogger) Error(entries ...interface{}) {
@@ -111,7 +115,7 @@ func (p *PackageLogger) Error(entries ...interface{}) {
 // Warning Functions
 
 func (p *PackageLogger) Warningf(format string, args ...interface{}) {
-	p.Logf(WARNING, format, args...)
+	p.logf(calldepth, WARNING, format, args...)
 }
 
 func (p *PackageLogger) Warning(entries ...interface{}) {
@@ -121,7 +125,7 @@ func (p *PackageLogger) Warning(entries ...interface{}) {
 // Notice Functions
 
 func (p *PackageLogger) Noticef(format string, args ...interface{}) {
-	p.Logf(NOTICE, format, args...)
+	p.logf(calldepth, NOTICE, format, args...)
 }
 
 func (p *PackageLogger) Notice(entries ...interface{}) {
@@ -131,7 +135,7 @@ func (p *PackageLogger) Notice(entries ...interface{}) {
 // Info Functions
 
 func (p *PackageLogger) Infof(format string, args ...interface{}) {
-	p.Logf(INFO, format, args...)
+	p.logf(calldepth, INFO, format, args...)
 }
 
 func (p *PackageLogger) Info(entries ...interface{}) {
@@ -144,7 +148,7 @@ func (p *PackageLogger) Debugf(format string, args ...interface{}) {
 	if p.level < DEBUG {
 		return
 	}
-	p.Logf(DEBUG, format, args...)
+	p.logf(calldepth, DEBUG, format, args...)
 }
 
 func (p *PackageLogger) Debug(entries ...interface{}) {
@@ -160,7 +164,7 @@ func (p *PackageLogger) Tracef(format string, args ...interface{}) {
 	if p.level < TRACE {
 		return
 	}
-	p.Logf(TRACE, format, args...)
+	p.logf(calldepth, TRACE, format, args...)
 }
 
 func (p *PackageLogger) Trace(entries ...interface{}) {


### PR DESCRIPTION
                +1 on call depth pointer
pkg_logger.go:  - make logging functions with variadic parameters
                call new logf (including Logf)
formatters.go:  - change const depth of 5 to calculated in LogFormatter
hello_dolly.go: - add Error()/Errorf() calls via GlogFormatter and LogFormatter
                to show we can mimic original Glog output format or integrate
                "log" pkg, and that the call depth is properly balanced
                when calling Formatter.Format() method

Variadic variants of logging functions initially wrapped Logf(), while
the others called internalLog() directly. This was making the caller's
stack depth uneven between the various calls which as a result was
making runtime.Caller() returning not correct line/file (in the already
present Formatter implementations or custom ones).